### PR TITLE
Fix Pinecone import for compatibility

### DIFF
--- a/document_processor.py
+++ b/document_processor.py
@@ -3,7 +3,12 @@ import streamlit as st
 from dotenv import load_dotenv
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_openai import OpenAIEmbeddings
-from langchain_pinecone import PineconeVectorStore
+try:
+    # Older versions of langchain_pinecone exposed `PineconeVectorStore` directly
+    from langchain_pinecone import PineconeVectorStore
+except ImportError:  # pragma: no cover - handle new package versions
+    # Newer releases renamed the class to `Pinecone`
+    from langchain_pinecone import Pinecone as PineconeVectorStore
 from pinecone import Pinecone
 import hashlib
 from datetime import datetime

--- a/test_import.py
+++ b/test_import.py
@@ -1,8 +1,11 @@
 try:
     import langchain_pinecone
     print("Successfully imported 'langchain_pinecone'")
-    from langchain_pinecone import PineconeVectorStore
-    print("Successfully imported 'PineconeVectorStore' from 'langchain_pinecone'")
+    try:
+        from langchain_pinecone import PineconeVectorStore
+    except ImportError:
+        from langchain_pinecone import Pinecone as PineconeVectorStore
+    print("Successfully imported 'PineconeVectorStore' (alias) from 'langchain_pinecone'")
     print("Test Succeeded")
 except ImportError as e:
     print(f"ImportError: {e}")


### PR DESCRIPTION
## Summary
- handle renamed PineconeVectorStore import
- update simple import test to match

## Testing
- `python test_import.py` *(fails: No module named 'langchain_pinecone')*

------
https://chatgpt.com/codex/tasks/task_e_6851317c85a48330996fb3314d2bd447