### PR TITLE
Add local file upload and confirm reprocess

### DIFF
--- a/google_drive_manager.py
+++ b/google_drive_manager.py
@@ -361,9 +361,39 @@ class GoogleDriveManager:
             ).execute()
             
             return file.get('id')
-            
+
         except Exception as e:
             print(f"Error uploading file: {e}")
+            return None
+
+    def upload_file_object(self, file_data, filename, mime_type='application/octet-stream'):
+        """Upload a binary file object to Google Drive"""
+        try:
+            if not self.service:
+                return None
+
+            # Prevent overwriting existing files
+            if self.file_exists(filename):
+                print(f"File '{filename}' already exists in Drive")
+                return None
+
+            media = MediaIoBaseUpload(io.BytesIO(file_data), mimetype=mime_type)
+
+            file_metadata = {
+                'name': filename,
+                'parents': [self.folder_id]
+            }
+
+            file = self.service.files().create(
+                body=file_metadata,
+                media_body=media,
+                fields='id'
+            ).execute()
+
+            return file.get('id')
+
+        except Exception as e:
+            print(f"Error uploading file object: {e}")
             return None
     
     def delete_file(self, file_id):


### PR DESCRIPTION
## Summary
- allow uploading local files in the "Add Document" page
- support binary uploads in `GoogleDriveManager`
- clean up vectors when reprocessing a file
- warn the user before reprocessing

## Testing
- `pytest -q`
- `python test_import.py` *(fails: No module named 'langchain_pinecone')*

------
https://chatgpt.com/codex/tasks/task_e_68525ac3005c8330bbe46113b39179c0